### PR TITLE
Removal of bad reference

### DIFF
--- a/1.6/Patches/_ModSettings/Toggleable-Patches.xml
+++ b/1.6/Patches/_ModSettings/Toggleable-Patches.xml
@@ -1064,23 +1064,6 @@
 					</li>
 				</value>
 			</li>
-			<li Class="PatchOperationAddModExtension" MayRequireAnyOf="DankPyon.Medieval.Overhaul">
-				<xpath>/Defs/BiomeDef[defName="DankPyon_AncientForest"]</xpath>
-				<value>
-					<li Class="ReGrowthCore.BiomesKitControl">
-						<forested>true</forested>
-						<uniqueHills>true</uniqueHills>
-						<forestDenseAbove>1100</forestDenseAbove>
-						<mountainsSemiSnowyBelow>10</mountainsSemiSnowyBelow>
-						<impassableSemiSnowyBelow>25</impassableSemiSnowyBelow>
-						<materialRandomRotation>false</materialRandomRotation>
-						<smallHillSizeMultiplier>1.5</smallHillSizeMultiplier>
-						<largeHillSizeMultiplier>2</largeHillSizeMultiplier>
-						<mountainSizeMultiplier>1.4</mountainSizeMultiplier>
-						<impassableSizeMultiplier>1.3</impassableSizeMultiplier>
-					</li>
-				</value>
-			</li>
 			<!-- ================ Outland: Toxic Forest ================ -->
 			<li Class="PatchOperationAddModExtension" MayRequire="Neronix17.Outland.ToxicForest">
 				<xpath>/Defs/BiomeDef[defName="Outland_ToxicForest"]</xpath>


### PR DESCRIPTION
DankPyon_AncientForest has not been a reference since, I believe, 1.4. Removing this in the 1.6 folder.
Fixes #15 